### PR TITLE
Fix query builder method case

### DIFF
--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -414,7 +414,7 @@ class WebhookController extends Controller
             $this->approveChatJoinRequest($chatId, $userId);
         }
         $reactions = Reaction::whereNull('chat_id')
-                              ->Orwhere('chat_id',$this->chat->id)
+                              ->orWhere('chat_id', $this->chat->id)
                               ->get();
         foreach ($reactions as $reaction) {
             $keyPhrase = $reaction->key_phrase;


### PR DESCRIPTION
## Summary
- fix `Orwhere` typo to `orWhere`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437d86fdcc8327916eef20c0d444c7