### PR TITLE
Fix AISpamDetectorTest

### DIFF
--- a/app/Actions/AISpamDetector.php
+++ b/app/Actions/AISpamDetector.php
@@ -5,7 +5,8 @@ namespace App\Actions;
 class AISpamDetector
 {
     public static function detectSpam(
-        string $message
+        string $message,
+        $client = null
     ): int
     {
         $text = 'Проанализируй это сообщение на предмет спама. Дай свою оценку в процентах от 0 до 100. '.
@@ -18,7 +19,9 @@ class AISpamDetector
             ' Кроме того проверь не является ли сообщение пользователя известным мемом.'.
             'Напиши только цифру в ответе. '.
             'Сообщение пользователя: ' . $message;
-        $client = \OpenAI::client(config('bot.openapi_token'));
+        if (!$client) {
+            $client = \OpenAI::client(config('bot.openapi_token'));
+        }
         $response = $client->chat()->create([
                                                 'model' => 'gpt-4o',
                                                 'messages' => [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,8 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
     </php>

--- a/tests/Unit/AISpamDetectorTest.php
+++ b/tests/Unit/AISpamDetectorTest.php
@@ -16,8 +16,6 @@ class AISpamDetectorTest extends TestCase
 
     public function test_detect_spam_returns_integer()
     {
-        $this->markTestSkipped('Unable to mock OpenAI static client in this environment.');
-
         $chatMock = new class {
             public function create(array $params)
             {
@@ -34,10 +32,8 @@ class AISpamDetectorTest extends TestCase
             public function chat() { return $this->chat; }
         };
 
-        Mockery::mock('alias:OpenAI')
-            ->shouldReceive('client')
-            ->andReturn($clientMock);
+        $this->assertSame(5, AISpamDetector::detectSpam('test', $clientMock));
 
-        $this->assertSame(5, AISpamDetector::detectSpam('test'));
+        $this->addToAssertionCount(1);
     }
 }


### PR DESCRIPTION
## Summary
- allow injecting OpenAI client into `AISpamDetector`
- update test to use injected client
- configure PHPUnit to run on SQLite in-memory database

## Testing
- `vendor/bin/phpunit --filter AISpamDetectorTest`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6844797354248327b49fd7b089afa367